### PR TITLE
Update python-pyhash.spec

### DIFF
--- a/upstream/rpm/specs/python-pyhash/python-pyhash.spec
+++ b/upstream/rpm/specs/python-pyhash/python-pyhash.spec
@@ -14,7 +14,7 @@ Source0:        https://pypi.python.org/packages/source/p/%{pkg}/%{pkg}-0.6.2.ta
 
 BuildRequires:  python-devel
 BuildRequires:  boost-devel
-BuildRequires:  python2-pip
+#BuildRequires:  python2-pip
 
 %description
 pyhash is a python non-cryptographic hash library, including FNV1,
@@ -25,6 +25,7 @@ MurmurHash1/2/3, lookup3, SuperFastHash, CityHash, SpookyHash etc
 # on downloading the zip archive due to redirects
 %prep
 %setup -q -n %{pkg}-%{version}
+curl https://bootstrap.pypa.io/get-pip.py | python
 pip install https://files.pythonhosted.org/packages/98/9c/079cd02e1511fa0bc155af16a333aef6a33d9753e7cb2ba201f4cbd79b0c/setuptools-5.4.1.zip
 
 %build


### PR DESCRIPTION
Delete python2-pip from dependencies but add pip to prep module. This fix permissions problem in chroot container when rpmbuild try update system files without root permissions.